### PR TITLE
feat: implement Observer pattern for cascading Recalc

### DIFF
--- a/src/components/flightphases/FlightPlan.vue
+++ b/src/components/flightphases/FlightPlan.vue
@@ -88,7 +88,6 @@
             text-color="black"
             color="warning"
             class="q-mr-sm"
-            @click="phase.Recalc()"
           >
             <div class="row no-wrap q-pa-md">
               <div class="column">
@@ -96,14 +95,6 @@
               </div>
             </div>
           </q-btn-dropdown>
-          <q-btn
-            dense
-            icon="fas fa-calculator"
-            color="accent"
-            size="md"
-            class="q-mr-sm"
-            @click="phase.Recalc()"
-          ></q-btn>
           <q-btn
             v-if="phase.isLastPhase()"
             dense

--- a/src/service/FlightPhase.ts
+++ b/src/service/FlightPhase.ts
@@ -91,7 +91,12 @@ export abstract class FlightPhase implements IFlightPhase {
     }
   }
 
-  abstract Recalc(): void;
+  protected abstract doRecalc(): void;
+
+  Recalc(): void {
+    this.doRecalc();
+    this.nextPhase?.Recalc();
+  }
 
   isLastPhase(): boolean {
     return this.nextPhase === null;

--- a/src/service/flight/ClimbPhase.ts
+++ b/src/service/flight/ClimbPhase.ts
@@ -55,7 +55,7 @@ export class ClimbPhase extends FlightPhase {
     return this.distance;
   }
 
-  Recalc() {
+  doRecalc() {
     this.FuelUsed();
     this.Duration();
     this.Distance();

--- a/src/service/flight/CombatPhase.ts
+++ b/src/service/flight/CombatPhase.ts
@@ -14,6 +14,7 @@ export class CombatPhase extends FlightPhase {
   }
 
   doRecalc() {
+    this.altitude = this.getStartingAltitude();
     this.FuelUsed();
   }
 

--- a/src/service/flight/CombatPhase.ts
+++ b/src/service/flight/CombatPhase.ts
@@ -13,7 +13,7 @@ export class CombatPhase extends FlightPhase {
     return this.fuelUsed;
   }
 
-  Recalc() {
+  doRecalc() {
     this.FuelUsed();
   }
 

--- a/src/service/flight/CruisePhase.ts
+++ b/src/service/flight/CruisePhase.ts
@@ -60,7 +60,7 @@ export class CruisePhase extends FlightPhase {
     return duration;
   }
 
-  Recalc() {
+  doRecalc() {
     this.FuelUsed();
     this.Duration();
     this.altitude = this.getStartingAltitude();

--- a/src/service/flight/CruisePhase.ts
+++ b/src/service/flight/CruisePhase.ts
@@ -61,9 +61,9 @@ export class CruisePhase extends FlightPhase {
   }
 
   doRecalc() {
+    this.altitude = this.getStartingAltitude();
     this.FuelUsed();
     this.Duration();
-    this.altitude = this.getStartingAltitude();
   }
 
   ChangeDistance(distance: number) {

--- a/src/service/flight/DescentPhase.ts
+++ b/src/service/flight/DescentPhase.ts
@@ -50,7 +50,7 @@ export class DescentPhase extends FlightPhase {
     return this.calculateDescentValue(DistancePenetrationDescent);
   }
 
-  Recalc() {
+  doRecalc() {
     this.fuelUsed = this.FuelUsed();
     this.duration = this.Duration();
     this.distance = this.Distance();

--- a/src/service/flight/LandingPhase.ts
+++ b/src/service/flight/LandingPhase.ts
@@ -25,6 +25,7 @@ export class LandingPhase extends FlightPhase {
   }
 
   doRecalc() {
+    this.altitude = this.getStartingAltitude();
     this.FuelUsed();
     this.Duration();
     this.Distance();

--- a/src/service/flight/LandingPhase.ts
+++ b/src/service/flight/LandingPhase.ts
@@ -24,7 +24,7 @@ export class LandingPhase extends FlightPhase {
     return this.distance;
   }
 
-  Recalc() {
+  doRecalc() {
     this.FuelUsed();
     this.Duration();
     this.Distance();

--- a/src/service/flight/RefuelPhase.ts
+++ b/src/service/flight/RefuelPhase.ts
@@ -8,7 +8,7 @@ export class RefuelPhase extends FlightPhase {
     this.altitude = this.getStartingAltitude();
   }
 
-  Recalc() {
+  doRecalc() {
     // this.FuelUsed();
   }
 }

--- a/src/service/flight/RefuelPhase.ts
+++ b/src/service/flight/RefuelPhase.ts
@@ -9,6 +9,7 @@ export class RefuelPhase extends FlightPhase {
   }
 
   doRecalc() {
+    this.altitude = this.getStartingAltitude();
     // this.FuelUsed();
   }
 }

--- a/src/service/flight/TakeOffPhase.ts
+++ b/src/service/flight/TakeOffPhase.ts
@@ -11,7 +11,7 @@ export class TakeOffPhase extends FlightPhase {
     this.Recalc();
   }
 
-  Recalc() {
+  doRecalc() {
     this.setStartWeight(this.context.takeOffWeight);
     this.setFuelOnBoard(this.context.fuelWeight);
     this.setStartingAltitude(this.context.airportPressureAltitude);


### PR DESCRIPTION
When a flight phase is recalculated, all downstream phases in the chain now automatically recalculate as well.

Applied Template Method pattern on FlightPhase:
- abstract Recalc() becomes protected abstract doRecalc()
- Concrete Recalc() calls doRecalc() then nextPhase?.Recalc() propagating changes through the full phase chain

All subclasses (TakeOffPhase, ClimbPhase, CruisePhase, CombatPhase, DescentPhase, LandingPhase, RefuelPhase) renamed Recalc() to doRecalc().