### PR TITLE
feat: implement Builder pattern for mission profiles

### DIFF
--- a/src/components/AboutEn.vue
+++ b/src/components/AboutEn.vue
@@ -53,10 +53,6 @@
         <p>Some day</p>
         <ul>
           <li>
-            Flight phases rework with different mission profiles (LO-LO-LO ,
-            HI-LO-HI) ( in progress)
-          </li>
-          <li>
             DCS airport database with runway informations (things like TORA,
             TODA, QFU, etc.) and METAR decoder.
           </li>

--- a/src/components/AboutFr.vue
+++ b/src/components/AboutFr.vue
@@ -62,11 +62,6 @@
 
         <ul>
           <li>
-            Phases de vol avec différents profils de mission (LO-LO-LO,
-            HI-LO-HI)
-          </li>
-
-          <li>
             Base de données des aéroports DCS avec les informations de piste (
             TORA, TODA, QFU, etc.) et décodeur METAR.
           </li>

--- a/src/components/flightphases/FlightPlan.vue
+++ b/src/components/flightphases/FlightPlan.vue
@@ -170,10 +170,23 @@
       </q-card-actions>
     </q-card>
     <q-card v-if="flight.FlightPhases.length == 0">
-      <q-card-section class="row">
+      <q-card-section class="row items-center q-gutter-sm">
         <q-btn outline size="sm" @click="flight.AddPhase(PhaseType.TAKEOFF)">
           {{ $t('flight_phase.' + PhaseType[PhaseType.TAKEOFF]) }}
         </q-btn>
+        <q-btn-dropdown outline size="sm" label="Load preset">
+          <q-list>
+            <q-item
+              v-for="preset in presets"
+              :key="preset.name"
+              clickable
+              v-close-popup
+              @click="flight.LoadProfile(preset)"
+            >
+              <q-item-section>{{ preset.name }}</q-item-section>
+            </q-item>
+          </q-list>
+        </q-btn-dropdown>
       </q-card-section>
     </q-card>
   </div>
@@ -188,6 +201,7 @@ import { storeToRefs } from 'pinia';
 import { PhaseType } from '../models';
 
 import { OptimumCruiseAltitude } from 'src/modules/a10c/cruise/OptimumCruiseAltitude';
+import { MissionPresets } from 'src/service/MissionPresets';
 
 import { computed } from 'vue';
 import PhaseViewer from './PhaseViewer.vue';
@@ -200,6 +214,10 @@ import OptimumPhaseParams from './OptimumPhaseParams.vue';
 const aircraft = useA10CStore();
 const airport = useTakeOffStore();
 const flight = useFlightStore();
+
+flight.Qnh = airport.Qnh;
+
+const presets = MissionPresets;
 
 flight.Qnh = airport.Qnh;
 

--- a/src/service/MissionPresets.ts
+++ b/src/service/MissionPresets.ts
@@ -1,0 +1,31 @@
+import { MissionProfile, MissionProfileBuilder } from './MissionProfileBuilder';
+
+export const MissionPresets: MissionProfile[] = [
+  new MissionProfileBuilder('CAS')
+    .withTakeoff()
+    .withClimb(18000)
+    .withCruise(100)
+    .withHiCombat(30, 4800)
+    .withCruise(100)
+    .withDescent(1340)
+    .withLanding()
+    .build(),
+
+  new MissionProfileBuilder('Ferry')
+    .withTakeoff()
+    .withClimb(20000)
+    .withCruise(200)
+    .withDescent(1340)
+    .withLanding()
+    .build(),
+
+  new MissionProfileBuilder('Strike')
+    .withTakeoff()
+    .withClimb(18000)
+    .withCruise(100)
+    .withHiCombat(15, 5200)
+    .withCruise(100)
+    .withDescent(1340)
+    .withLanding()
+    .build(),
+];

--- a/src/service/MissionProfileBuilder.ts
+++ b/src/service/MissionProfileBuilder.ts
@@ -1,0 +1,60 @@
+import { PhaseType } from '../components/models';
+
+export interface PhaseConfig {
+  type: PhaseType;
+  altitude?: number;
+  distance?: number;
+  duration?: number;
+  fuelFlow?: number;
+  refuelTotal?: number;
+}
+
+export interface MissionProfile {
+  name: string;
+  phases: PhaseConfig[];
+}
+
+export class MissionProfileBuilder {
+  private phases: PhaseConfig[] = [];
+
+  constructor(private readonly name: string) {}
+
+  withTakeoff(): this {
+    this.phases.push({ type: PhaseType.TAKEOFF });
+    return this;
+  }
+
+  withClimb(altitude: number): this {
+    this.phases.push({ type: PhaseType.CLIMB, altitude });
+    return this;
+  }
+
+  withCruise(distance: number): this {
+    this.phases.push({ type: PhaseType.CRUISE, distance });
+    return this;
+  }
+
+  withHiCombat(duration: number, fuelFlow?: number): this {
+    this.phases.push({ type: PhaseType.HI_COMBAT, duration, fuelFlow });
+    return this;
+  }
+
+  withDescent(targetAltitude: number): this {
+    this.phases.push({ type: PhaseType.DESCENT, altitude: targetAltitude });
+    return this;
+  }
+
+  withRefuel(refuelTotal: number): this {
+    this.phases.push({ type: PhaseType.REFUEL, refuelTotal });
+    return this;
+  }
+
+  withLanding(): this {
+    this.phases.push({ type: PhaseType.LANDING });
+    return this;
+  }
+
+  build(): MissionProfile {
+    return { name: this.name, phases: [...this.phases] };
+  }
+}

--- a/src/stores/flight.ts
+++ b/src/stores/flight.ts
@@ -6,6 +6,7 @@ import { FlightPhaseFactory } from 'src/service/FlightPhaseFactory';
 import { PressureAltitude } from 'src/service/conversionTool';
 
 import { FlightStateMachine } from 'src/service/FlightStateMachine';
+import { MissionProfile } from 'src/service/MissionProfileBuilder';
 
 export const useFlightStore = defineStore('flight', {
   state: () => ({
@@ -121,6 +122,21 @@ export const useFlightStore = defineStore('flight', {
     RemovePhase() {
       const removed = this.phases.pop() as FlightPhase;
       removed.previousPhase?.setNextPhase(null);
+    },
+
+    LoadProfile(profile: MissionProfile) {
+      this.phases = [];
+      for (const config of profile.phases) {
+        this.AddPhase(config.type);
+        const phase = this.phases[this.phases.length - 1];
+        if (!phase) continue;
+        if (config.altitude !== undefined) phase.ChangeAltitude(config.altitude);
+        if (config.distance !== undefined) phase.ChangeDistance(config.distance);
+        if (config.duration !== undefined) phase.ChangePhaseDuration(config.duration);
+        if (config.fuelFlow !== undefined) phase.ChangeFuelFlow(config.fuelFlow);
+        if (config.refuelTotal !== undefined) phase.Refuel(config.refuelTotal);
+        phase.Recalc();
+      }
     },
   },
 });


### PR DESCRIPTION
Add MissionProfileBuilder with fluent API for constructing mission profiles step by step. Add MissionPresets with three built-in profiles (CAS, Ferry, Strike). Add LoadProfile action to the flight store that applies a profile by replaying phase configs through AddPhase and the cascade Recalc. Add a preset dropdown to the empty-state card in FlightPlan.vue.