### PR TITLE
feat: tabular flight plan layout

### DIFF
--- a/src/components/flightphases/FlightPlan.vue
+++ b/src/components/flightphases/FlightPlan.vue
@@ -1,194 +1,92 @@
 <template>
-  <div class="q-pa-sm items-start q-gutter-sm">
-    <!-- summary -->
+  <div class="q-pa-sm q-gutter-sm">
+
+    <!-- Summary card -->
     <q-card>
       <q-card-section class="text-h6 bg-primary text-white" horizontal>
-        <q-card-section class="row">
+        <q-card-section class="row items-center">
           <q-item class="q-mr-md">{{ $t('flight_phase.summary') }}</q-item>
           <q-input
-            filled
-            dense
-            debounce="500"
-            dark
-            class="q-mr-md"
+            filled dense debounce="500" dark hide-bottom-space class="q-mr-md"
             v-model.number="fuelReserve"
             :label="$t('flight_phase.reserve')"
             :rules="[(val) => val >= 0]"
-          ></q-input>
+          />
           <q-input
-            filled
-            dense
-            dark
-            debounce="500"
-            class="q-mr-md"
+            filled dense dark debounce="500" class="q-mr-md"
             v-model.number="missionRange"
             :label="$t('flight_phase.mission_range')"
-          ></q-input>
+          />
         </q-card-section>
       </q-card-section>
-      <q-card-section class="row">
-        <ShowItem
-          :label="$t('flight_phase.cruise_alt')"
-          :value="flight.CruiseAltitude.toFixed(0)"
-          unit="ft"
-        />
-        <ShowItem
-          :label="$t('flight_phase.optimum_cruise_alt')"
-          :value="optimum_cruise_altitude.toFixed(0)"
-          unit="ft"
-        />
-
-        <ShowItem
-          :label="$t('flight_phase.distance')"
-          :value="flight.TotalDistance.toFixed(0)"
-          unit="NM"
-        />
-
-        <ShowItem
-          :label="$t('flight_phase.duration')"
-          :value="flight.TotalDuration.toFixed(0)"
-          unit="Min"
-        />
-        <ShowItem
-          :label="$t('flight_phase.fuel_used')"
-          :value="flight.TotalFuelUsed.toFixed(0)"
-          unit="lbs"
-        />
-        <ShowItem
-          :label="$t('flight_phase.std_day_temp_dev')"
-          :value="airport.DeltaTemp"
-          unit="°C"
-        />
-        <ShowItem
-          :label="$t('flight_phase.bingo')"
-          :value="flight.Bingo"
-          unit="lbs"
-        />
+      <q-card-section class="row q-col-gutter-md">
+        <ShowItem :label="$t('flight_phase.cruise_alt')" :value="flight.CruiseAltitude.toFixed(0)" unit="ft" />
+        <ShowItem :label="$t('flight_phase.optimum_cruise_alt')" :value="optimum_cruise_altitude.toFixed(0)" unit="ft" />
+        <ShowItem :label="$t('flight_phase.distance')" :value="flight.TotalDistance.toFixed(0)" unit="NM" />
+        <ShowItem :label="$t('flight_phase.duration')" :value="flight.TotalDuration.toFixed(0)" unit="Min" />
+        <ShowItem :label="$t('flight_phase.fuel_used')" :value="flight.TotalFuelUsed.toFixed(0)" unit="lbs" />
+        <ShowItem :label="$t('flight_phase.std_day_temp_dev')" :value="airport.DeltaTemp" unit="°C" />
+        <ShowItem :label="$t('flight_phase.bingo')" :value="flight.Bingo" unit="lbs" />
       </q-card-section>
     </q-card>
-    <q-card> </q-card>
 
-    <q-card v-for="(phase, index) in flight.FlightPhases" :key="index">
-      <div
-        class="row justify-between bg-secondary text-white q-pa-md items-center"
-      >
-        <div class="row items-center">
-          <span class="text-h6 q-mr-md">{{
-            $t('flight_phase.' + PhaseType[phase.type])
-          }}</span>
-          <OptimumPhaseParams :phase="phase" />
-        </div>
-        <div class="row items-center">
-          <ShowWind :wind="phase.wind.Winds(phase.course)" horizontal />
-          <q-btn-dropdown
-            v-if="phase.type != PhaseType.TAKEOFF"
-            dense
-            icon="fas fa-wind"
-            size="sm"
-            text-color="black"
-            color="warning"
-            class="q-mr-sm"
-          >
-            <div class="row no-wrap q-pa-md">
-              <div class="column">
-                <CourseAndWind :phase="phase" />
-              </div>
-            </div>
-          </q-btn-dropdown>
-          <q-btn
-            v-if="phase.isLastPhase()"
-            dense
-            color="negative"
-            icon="delete"
-            @click="flight.RemovePhase()"
+    <!-- Phase table -->
+    <div style="overflow-x: auto">
+      <q-markup-table flat bordered dense separator="cell">
+        <thead>
+          <tr class="bg-grey-3 text-grey-9">
+            <th class="text-left">{{ $t('flight_phase.phase') }}</th>
+            <th class="text-right">{{ $t('flight_phase.starting_weight') }}<br><span class="text-caption">(lbs)</span></th>
+            <th class="text-right">{{ $t('flight_phase.efob') }}<br><span class="text-caption">(lbs)</span></th>
+            <th class="text-right">{{ $t('flight_phase.fuel_used') }}<br><span class="text-caption">(lbs)</span></th>
+            <th class="text-right">{{ $t('flight_phase.starting_altitude') }}</th>
+            <th class="text-right">{{ $t('flight_phase.fuel_flow') }}<br><span class="text-caption">(lbs/h)</span></th>
+            <th class="text-right">{{ $t('flight_phase.altitude') }}</th>
+            <th class="text-right">{{ $t('flight_phase.distance') }}<br><span class="text-caption">(NM)</span></th>
+            <th class="text-right">{{ $t('flight_phase.duration') }}<br><span class="text-caption">(min)</span></th>
+            <th class="text-right gt-xs">{{ $t('flight_phase.drag') }}</th>
+            <th class="text-center">{{ $t('flight_phase.wind') }}</th>
+          </tr>
+        </thead>
+        <tbody>
+          <PhaseTableRow
+            v-for="(phase, index) in flight.FlightPhases"
+            :key="index"
+            :phase="phase"
+            :reserve="fuelReserve"
+            @remove="flight.RemovePhase()"
           />
-        </div>
-      </div>
+        </tbody>
+      </q-markup-table>
+    </div>
 
-      <q-card-section>
-        <PhaseViewer
-          v-if="phase.type == PhaseType.TAKEOFF"
-          :phase="phase"
-          :reserve="fuelReserve"
-        />
-        <PhaseViewer
-          v-else-if="phase.type == PhaseType.CLIMB"
-          :phase="phase"
-          :reserve="fuelReserve"
-          edit-altitude
-        />
-        <PhaseViewer
-          v-else-if="phase.type == PhaseType.CRUISE"
-          :phase="phase"
-          :reserve="fuelReserve"
-          edit-distance
-        />
-        <PhaseViewer
-          v-else-if="phase.type == PhaseType.HI_COMBAT"
-          :phase="phase"
-          :reserve="fuelReserve"
-          edit-duration
-          edit-fuel-flow
-        />
-        <PhaseViewer
-          v-else-if="phase.type == PhaseType.REFUEL"
-          :phase="phase"
-          :reserve="fuelReserve"
-          edit-f-o-b
-        />
-        <PhaseViewer
-          v-else-if="phase.type == PhaseType.DESCENT"
-          :phase="phase"
-          :reserve="fuelReserve"
-          edit-altitude
-        />
-        <PhaseViewer
-          v-else-if="phase.type == PhaseType.LANDING"
-          :phase="phase"
-          :reserve="fuelReserve"
-        />
-      </q-card-section>
-
-      <q-card-actions v-if="phase.isLastPhase()">
-        <q-btn
-          v-if="flight.phases.length == 0"
-          outline
-          size="sm"
-          @click="flight.AddPhase(PhaseType.TAKEOFF)"
-          >{{ $t('flight_phase.' + PhaseType[PhaseType.TAKEOFF]) }}</q-btn
-        >
-
-        <q-btn
-          class="q-mr-sm"
-          outline
-          size="sm"
-          v-for="(possible, idxPhase) in flight.NextPhases"
-          :key="idxPhase"
-          @click="flight.AddPhase(possible)"
-          >{{ $t('flight_phase.' + PhaseType[possible]) }}
-        </q-btn>
-      </q-card-actions>
-    </q-card>
-    <q-card v-if="flight.FlightPhases.length == 0">
-      <q-card-section class="row items-center q-gutter-sm">
+    <!-- Add phase / preset buttons -->
+    <div class="row items-center q-gutter-sm">
+      <template v-if="flight.FlightPhases.length === 0">
         <q-btn outline size="sm" @click="flight.AddPhase(PhaseType.TAKEOFF)">
           {{ $t('flight_phase.' + PhaseType[PhaseType.TAKEOFF]) }}
         </q-btn>
         <q-btn-dropdown outline size="sm" label="Load preset">
           <q-list>
             <q-item
-              v-for="preset in presets"
-              :key="preset.name"
-              clickable
-              v-close-popup
+              v-for="preset in presets" :key="preset.name"
+              clickable v-close-popup
               @click="flight.LoadProfile(preset)"
             >
               <q-item-section>{{ preset.name }}</q-item-section>
             </q-item>
           </q-list>
         </q-btn-dropdown>
-      </q-card-section>
-    </q-card>
+      </template>
+      <template v-else-if="flight.NextPhases.length > 0">
+        <q-btn
+          v-for="(possible, i) in flight.NextPhases" :key="i"
+          outline size="sm" class="q-mr-xs"
+          @click="flight.AddPhase(possible)"
+        >{{ $t('flight_phase.' + PhaseType[possible]) }}</q-btn>
+      </template>
+    </div>
+
   </div>
 </template>
 
@@ -199,17 +97,12 @@ import { useFlightStore } from 'src/stores/flight';
 import { storeToRefs } from 'pinia';
 
 import { PhaseType } from '../models';
-
 import { OptimumCruiseAltitude } from 'src/modules/a10c/cruise/OptimumCruiseAltitude';
 import { MissionPresets } from 'src/service/MissionPresets';
 
 import { computed } from 'vue';
-import PhaseViewer from './PhaseViewer.vue';
-
 import ShowItem from './ShowItem.vue';
-import CourseAndWind from './CourseAndWind.vue';
-import ShowWind from '../ShowWind.vue';
-import OptimumPhaseParams from './OptimumPhaseParams.vue';
+import PhaseTableRow from './PhaseTableRow.vue';
 
 const aircraft = useA10CStore();
 const airport = useTakeOffStore();
@@ -218,18 +111,10 @@ const flight = useFlightStore();
 flight.Qnh = airport.Qnh;
 
 const presets = MissionPresets;
-
-flight.Qnh = airport.Qnh;
-
 const { missionRange, fuelReserve } = storeToRefs(flight);
 
-const optimum_cruise_altitude = computed(() => {
-  {
-    return OptimumCruiseAltitude(
-      aircraft.Drag,
-      aircraft.TakeOffWeight,
-      missionRange.value,
-    );
-  }
-});
+const optimum_cruise_altitude = computed(() =>
+  OptimumCruiseAltitude(aircraft.Drag, aircraft.TakeOffWeight, missionRange.value),
+);
 </script>
+

--- a/src/components/flightphases/PhaseTableRow.vue
+++ b/src/components/flightphases/PhaseTableRow.vue
@@ -1,0 +1,213 @@
+<template>
+  <tr>
+    <td class="text-no-wrap">
+      <q-btn
+        v-if="hasAdvice"
+        flat
+        dense
+        round
+        size="xs"
+        icon="info"
+        color="primary"
+        class="q-mr-xs"
+        @click="expanded = !expanded"
+      />
+      <strong>{{ $t('flight_phase.' + PhaseType[phase.type]) }}</strong>
+      <q-btn
+        v-if="phase.isLastPhase()"
+        dense flat round
+        color="negative"
+        icon="delete"
+        size="xs"
+        class="q-ml-xs"
+        @click="emit('remove')"
+      />
+    </td>
+
+    <td class="text-right">{{ phase.getStartingWeight().toFixed(0) }}</td>
+
+    <!-- EFOB — refuel input for REFUEL phase -->
+    <td
+      class="text-right"
+      :class="phase.getFuelOnBoard() < reserve ? 'text-negative' : ''"
+    >
+      <q-input
+        v-if="phase.type === PhaseType.REFUEL"
+        dense
+        filled
+        debounce="500"
+        style="width: 90px"
+        :label="$t('flight_phase.quantity_refuelled')"
+        v-model.number="fuelOnBoard"
+        :rules="[(val) => val > 0 || 'You must refuel']"
+        @update:model-value="onRefuel"
+      />
+      <span v-else>{{ phase.getFuelOnBoard().toFixed(0) }}</span>
+    </td>
+
+    <td class="text-right">{{ phase.fuelUsed.toFixed(0) }}</td>
+    <td class="text-right">{{ phase.getStartingAltitude() }}</td>
+
+    <!-- Fuel Flow — editable for HI_COMBAT -->
+    <td class="text-right">
+      <q-input
+        v-if="phase.type === PhaseType.HI_COMBAT"
+        dense
+        filled
+        debounce="500"
+        style="width: 90px"
+        :label="$t('flight_phase.fuel_flow')"
+        v-model.number="fuelFlow"
+        @update:model-value="onFuelFlow"
+      />
+      <span v-else>{{ phase.fuelFlow.toFixed(0) }}</span>
+    </td>
+
+    <!-- Altitude — editable for CLIMB / DESCENT -->
+    <td class="text-right">
+      <q-input
+        v-if="
+          phase.type === PhaseType.CLIMB || phase.type === PhaseType.DESCENT
+        "
+        dense
+        filled
+        debounce="500"
+        style="width: 80px"
+        :label="$t('flight_phase.altitude')"
+        v-model.number="altitude"
+        :rules="[checkAltitude]"
+        @update:model-value="onAltitude"
+      />
+      <span v-else>{{ phase.altitude }}</span>
+    </td>
+
+    <!-- Distance — editable for CRUISE -->
+    <td class="text-right">
+      <q-input
+        v-if="phase.type === PhaseType.CRUISE"
+        dense
+        filled
+        debounce="500"
+        style="width: 80px"
+        :label="$t('flight_phase.distance')"
+        v-model.number="distance"
+        :rules="[(val) => val > 0 || $t('flight_phase.greater_than_zero')]"
+        @update:model-value="onDistance"
+      />
+      <span v-else>{{ phase.distance }}</span>
+    </td>
+
+    <!-- Duration — editable for HI_COMBAT -->
+    <td class="text-right">
+      <q-input
+        v-if="phase.type === PhaseType.HI_COMBAT"
+        dense
+        filled
+        debounce="500"
+        style="width: 80px"
+        :label="$t('flight_phase.duration_minutes')"
+        v-model.number="phaseDuration"
+        :rules="[(val) => val > 0 || $t('flight_phase.greater_than_zero')]"
+        @update:model-value="onDuration"
+      />
+      <span v-else>{{ phase.duration.toFixed(1) }}</span>
+    </td>
+
+    <td class="text-right gt-xs">{{ phase.drag.toFixed(2) }}</td>
+
+    <!-- Actions: wind dropdown only -->
+    <td class="text-center">
+      <q-btn-dropdown
+        v-if="phase.type !== PhaseType.TAKEOFF"
+        dense flat round
+        icon="fas fa-wind"
+        size="xs"
+        color="grey-7"
+      >
+        <div class="q-pa-md">
+          <CourseAndWind :phase="phase" />
+        </div>
+      </q-btn-dropdown>
+    </td>
+  </tr>
+
+  <!-- Collapsible advice row -->
+  <tr v-if="expanded">
+    <td colspan="11" class="bg-blue-grey-1 q-pa-sm">
+      <OptimumPhaseParams :phase="phase" />
+    </td>
+  </tr>
+</template>
+
+<script setup lang="ts">
+import { computed, onMounted, ref } from 'vue';
+import { IFlightPhase, PhaseType } from '../models';
+import { useI18n } from 'vue-i18n';
+import CourseAndWind from './CourseAndWind.vue';
+import OptimumPhaseParams from './OptimumPhaseParams.vue';
+
+const { t } = useI18n();
+
+const props = defineProps<{
+  phase: IFlightPhase;
+  reserve: number;
+}>();
+
+const emit = defineEmits<{ remove: [] }>();
+
+const expanded = ref(false);
+const altitude = ref(0);
+const distance = ref(0);
+const phaseDuration = ref(0);
+const fuelFlow = ref(0);
+const fuelOnBoard = ref(0);
+
+onMounted(() => {
+  altitude.value = props.phase.altitude;
+  distance.value = props.phase.distance;
+  phaseDuration.value = props.phase.duration;
+  fuelFlow.value = props.phase.fuelFlow;
+});
+
+const hasAdvice = computed(() =>
+  [
+    PhaseType.CLIMB,
+    PhaseType.CRUISE,
+    PhaseType.HI_COMBAT,
+    PhaseType.DESCENT,
+  ].includes(props.phase.type),
+);
+
+const checkAltitude = (val: number) => {
+  if (props.phase.type === PhaseType.DESCENT)
+    return (
+      val < props.phase.getStartingAltitude() ||
+      t('flight_phase.alt_must_be_lower')
+    );
+  return (
+    val > props.phase.getStartingAltitude() ||
+    t('flight_phase.alt_must_be_higher')
+  );
+};
+
+const onAltitude = () => {
+  props.phase.ChangeAltitude(altitude.value);
+  props.phase.Recalc();
+};
+const onDistance = () => {
+  props.phase.ChangeDistance(distance.value);
+  props.phase.Recalc();
+};
+const onDuration = () => {
+  props.phase.ChangePhaseDuration(phaseDuration.value);
+  props.phase.Recalc();
+};
+const onFuelFlow = () => {
+  props.phase.ChangeFuelFlow(fuelFlow.value);
+  props.phase.Recalc();
+};
+const onRefuel = () => {
+  props.phase.Refuel(fuelOnBoard.value);
+  props.phase.Recalc();
+};
+</script>

--- a/src/components/flightphases/ShowItem.vue
+++ b/src/components/flightphases/ShowItem.vue
@@ -1,8 +1,8 @@
 <template>
-  <q-item class="col-xs-3 col-sm-2 col-md-1">
+  <q-item class="col-xs-6 col-sm-4 col-md-2">
     <q-item-section>
-      <q-item-label> {{ label }} </q-item-label>
-      <span class="text-bold">{{ value }} {{ unit }}</span>
+      <q-item-label class="text-caption text-grey-7">{{ label }}</q-item-label>
+      <div class="text-bold text-body1">{{ value }} <span class="text-caption">{{ unit }}</span></div>
     </q-item-section>
   </q-item>
 </template>

--- a/src/i18n/en-US/index.ts
+++ b/src/i18n/en-US/index.ts
@@ -100,6 +100,7 @@ export default {
     DESCENT: 'Descent',
     LANDING: 'Landing',
 
+    wind: 'Wind',
     wind_direction: 'Wind direction',
     wind_speed: 'Wind speed',
     leg_course: 'Leg course',

--- a/src/i18n/fr-FR/index.ts
+++ b/src/i18n/fr-FR/index.ts
@@ -102,6 +102,7 @@ export default {
     DESCENT: 'Descente',
     LANDING: 'Atterrissage',
 
+    wind: 'Vent',
     wind_direction: 'Direction du vent',
     wind_speed: 'Vitesse du vent',
     leg_course: 'Cap',


### PR DESCRIPTION
- Replace stacked phase cards with compact q-markup-table
- Add PhaseTableRow component (Vue 3 fragment: data row + collapsible advice row)
- Move delete button into Phase column (inline after phase name)
- Add Wind column with dropdown for CourseAndWind
- Split column headers: unit on second line (text-caption) to reduce width
- Fix summary section: wider cols (col-md-2), q-col-gutter-md, better label/value hierarchy
- Fix header input alignment with hide-bottom-space on fuel reserve input
- Add flight_phase.wind i18n key (fr-FR + en-US)